### PR TITLE
Final merge r1.5.0 bugfixes and doc updates to main (#3232)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN git clone --depth 1 --branch release/0.10 https://github.com/pytorch/audio.g
 # TODO: remove when 21.04 container is released
 # build torchtext
 WORKDIR /tmp/torchtext_build
-RUN git clone --branch v0.11.0 https://github.com/pytorch/text.git && \
+RUN git clone --branch v0.11.0-rc3 https://github.com/pytorch/text.git && \
     cd text && \
     git submodule update --init --recursive && \
     python setup.py clean install && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -555,7 +555,7 @@ pipeline {
             pretrained_name="QuartzNet15x5Base-En" \
             audio_dir="/home/TestData/an4_transcribe/test_subset/" \
             output_filename="stt_test_res.json" \
-            cuda=true \
+            cuda=0 \
             amp=true'
             sh 'rm -rf stt_test_res.json'
           }

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,7 @@ Introduction
 NVIDIA NeMo is a conversational AI toolkit built for researchers working on automatic speech recognition (ASR), natural language processing (NLP), and text-to-speech synthesis (TTS).
 The primary objective of NeMo is to help researchers from industry and academia to reuse prior work (code and pretrained models and make it easier to create new `conversational AI models <https://developer.nvidia.com/conversational-ai#started>`_.
 
+`Pre-trained NeMo models. <https://catalog.ngc.nvidia.com/models?query=nemo&orderBy=weightPopularDESC>`_ 
 
 `Introductory video. <https://www.youtube.com/embed/wBgpMf_KQVw>`_
 
@@ -172,14 +173,13 @@ Megatron GPT training requires NVIDIA Apex to be installed.
 
     git clone https://github.com/NVIDIA/apex
     cd apex
+    git checkout 14ccf5986401104121d0ef286a29386904af3bb7
     pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 
 Docker containers:
 ~~~~~~~~~~~~~~~~~~
 
 If you chose to work with main branch, we recommend using NVIDIA's PyTorch container version 21.10-py3 and then installing from GitHub.
-Note NVIDIA's PyTorch 21.10-py3 has not yet been released publicly. Please use a container with the nightly version of PyTorch installed if you are 
-unable to access the NVIDIA's PyTorch 21.10 container.
 
 .. code-block:: bash
 
@@ -190,7 +190,7 @@ unable to access the NVIDIA's PyTorch 21.10 container.
 Examples
 --------
 
-Many example can be found under `"Examples" <https://github.com/NVIDIA/NeMo/tree/stable/examples>`_ folder.
+Many examples can be found under `"Examples" <https://github.com/NVIDIA/NeMo/tree/stable/examples>`_ folder.
 
 
 Contributing

--- a/docs/source/starthere/intro.rst
+++ b/docs/source/starthere/intro.rst
@@ -19,6 +19,8 @@ Conversational AI architectures are typically large and require a lot of data an
 for training. NeMo uses `PyTorch Lightning <https://www.pytorchlightning.ai/>`_ for easy and performant multi-GPU/multi-node
 mixed-precision training.
 
+`Pre-trained NeMo models. <https://catalog.ngc.nvidia.com/models?query=nemo&orderBy=weightPopularDESC>`_ 
+
 .. raw:: html
 
     <div style="position: relative; padding-bottom: 3%; height: 0; overflow: hidden; max-width: 100%; height: auto;">

--- a/examples/nlp/language_modeling/megatron_gpt_pretraining.py
+++ b/examples/nlp/language_modeling/megatron_gpt_pretraining.py
@@ -50,7 +50,7 @@ def main(cfg) -> None:
     exp_manager(trainer, cfg.exp_manager)
 
     # update resume from checkpoint found by exp_manager
-    resume_from_checkpoint = trainer.resume_from_checkpoint
+    resume_from_checkpoint = trainer.checkpoint_connector.resume_from_checkpoint_fit_path
     if resume_from_checkpoint is not None:
         # inject mp_rank into resume_from_checkpoint
         if cfg.model.tensor_model_parallel_size is not None and cfg.model.tensor_model_parallel_size > 1:

--- a/nemo/collections/asr/data/audio_to_label.py
+++ b/nemo/collections/asr/data/audio_to_label.py
@@ -386,9 +386,6 @@ class AudioToClassificationLabelDataset(_AudioLabelDataset):
         trim: Boolean flag whether to trim the audio
     """
 
-    # self.labels = labels if labels else self.collection.uniq_labels
-    # self.num_commands = len(self.labels)
-
     def _collate_fn(self, batch):
         return _speech_collate_fn(batch, pad_id=0)
 
@@ -545,7 +542,7 @@ class _TarredAudioLabelDataset(IterableDataset):
         self,
         *,
         audio_tar_filepaths: Union[str, List[str]],
-        manifest_filepath: str,
+        manifest_filepath: Union[str, List[str]],
         labels: List[str],
         featurizer,
         shuffle_n: int = 0,
@@ -558,7 +555,7 @@ class _TarredAudioLabelDataset(IterableDataset):
         is_regression_task: bool = False,
     ):
         self.collection = collections.ASRSpeechLabel(
-            manifests_files=manifest_filepath.split(','),
+            manifests_files=manifest_filepath,
             min_duration=min_duration,
             max_duration=max_duration,
             index_by_file_id=True,  # Must set this so the manifest lines can be indexed by file ID
@@ -869,7 +866,7 @@ class TarredAudioToSpeechLabelDataset(_TarredAudioLabelDataset):
         self,
         *,
         audio_tar_filepaths: Union[str, List[str]],
-        manifest_filepath: str,
+        manifest_filepath: Union[str, List[str]],
         labels: List[str],
         featurizer,
         shuffle_n: int = 0,

--- a/nemo/collections/asr/data/audio_to_label_dataset.py
+++ b/nemo/collections/asr/data/audio_to_label_dataset.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from torch.utils.data import ChainDataset
+
 from nemo.collections.asr.data import audio_to_label
+from nemo.collections.asr.data.audio_to_text_dataset import convert_to_config_list
 
 
 def get_classification_label_dataset(featurizer, config: dict) -> audio_to_label.AudioToClassificationLabelDataset:
@@ -110,20 +113,42 @@ def get_tarred_speech_label_dataset(
     Returns:
         An instance of TarredAudioToSpeechLabelDataset.
     """
-    dataset = audio_to_label.TarredAudioToSpeechLabelDataset(
-        audio_tar_filepaths=config['tarred_audio_filepaths'],
-        manifest_filepath=config['manifest_filepath'],
-        labels=config['labels'],
-        featurizer=featurizer,
-        shuffle_n=shuffle_n,
-        max_duration=config.get('max_duration', None),
-        min_duration=config.get('min_duration', None),
-        trim=config.get('trim_silence', False),
-        time_length=config.get('time_length', 0.31),
-        shift_length=config.get('shift_length', 0.01),
-        normalize_audio=config.get('normalize_audio', False),
-        shard_strategy=config.get('tarred_shard_strategy', 'scatter'),
-        global_rank=global_rank,
-        world_size=world_size,
-    )
-    return dataset
+    tarred_audio_filepaths = config['tarred_audio_filepaths']
+    manifest_filepaths = config['manifest_filepath']
+    datasets = []
+    tarred_audio_filepaths = convert_to_config_list(tarred_audio_filepaths)
+    manifest_filepaths = convert_to_config_list(manifest_filepaths)
+
+    if len(manifest_filepaths) != len(tarred_audio_filepaths):
+        raise ValueError(
+            f"manifest_filepaths (length={len(manifest_filepaths)}) and tarred_audio_filepaths (length={len(tarred_audio_filepaths)}) need to have the same number of buckets."
+        )
+
+    for dataset_idx, (tarred_audio_filepath, manifest_filepath) in enumerate(
+        zip(tarred_audio_filepaths, manifest_filepaths)
+    ):
+        if len(tarred_audio_filepath) == 1:
+            tarred_audio_filepath = tarred_audio_filepath[0]
+        dataset = audio_to_label.TarredAudioToSpeechLabelDataset(
+            audio_tar_filepaths=tarred_audio_filepath,
+            manifest_filepath=manifest_filepath,
+            labels=config['labels'],
+            featurizer=featurizer,
+            shuffle_n=shuffle_n,
+            max_duration=config.get('max_duration', None),
+            min_duration=config.get('min_duration', None),
+            trim=config.get('trim_silence', False),
+            time_length=config.get('time_length', 8),
+            shift_length=config.get('shift_length', 0.075),
+            normalize_audio=config.get('normalize_audio', False),
+            shard_strategy=config.get('tarred_shard_strategy', 'scatter'),
+            global_rank=global_rank,
+            world_size=world_size,
+        )
+
+        datasets.append(dataset)
+
+    if len(datasets) > 1:
+        return ChainDataset(datasets)
+    else:
+        return datasets[0]

--- a/nemo/collections/asr/data/audio_to_text.py
+++ b/nemo/collections/asr/data/audio_to_text.py
@@ -209,6 +209,9 @@ class _AudioTextDataset(Dataset):
         pad_id: int = 0,
         return_sample_id: bool = False,
     ):
+        if type(manifest_filepath) == str:
+            manifest_filepath = manifest_filepath.split(",")
+
         self.manifest_processor = ASRManifestProcessor(
             manifest_filepath=manifest_filepath,
             parser=parser,

--- a/nemo/collections/asr/models/label_models.py
+++ b/nemo/collections/asr/models/label_models.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import itertools
 import json
 import os
 import pickle as pkl
@@ -23,8 +24,11 @@ import torch
 from omegaconf import DictConfig
 from omegaconf.omegaconf import open_dict
 from pytorch_lightning import Trainer
+from torch.utils.data import ChainDataset
 
 from nemo.collections.asr.data.audio_to_label import AudioToSpeechLabelDataset
+from nemo.collections.asr.data.audio_to_label_dataset import get_tarred_speech_label_dataset
+from nemo.collections.asr.data.audio_to_text_dataset import convert_to_config_list
 from nemo.collections.asr.losses.angularloss import AngularSoftmaxLoss
 from nemo.collections.asr.models.asr_model import ExportableEncDecModel
 from nemo.collections.asr.parts.preprocessing.features import WaveformFeaturizer
@@ -32,6 +36,7 @@ from nemo.collections.asr.parts.preprocessing.perturb import process_augmentatio
 from nemo.collections.asr.parts.utils.speaker_utils import embedding_normalize
 from nemo.collections.common.losses import CrossEntropyLoss as CELoss
 from nemo.collections.common.metrics import TopKClassificationAccuracy
+from nemo.collections.common.parts.preprocessing.collections import ASRSpeechLabel
 from nemo.core.classes import ModelPT
 from nemo.core.classes.common import PretrainedModelInfo, typecheck
 from nemo.core.neural_types import *
@@ -89,7 +94,12 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel):
         return result
 
     def __init__(self, cfg: DictConfig, trainer: Trainer = None):
+        self.world_size = 1
+        if trainer is not None:
+            self.world_size = trainer.num_nodes * trainer.num_gpus
+
         super().__init__(cfg=cfg, trainer=trainer)
+
         self.preprocessor = EncDecSpeakerLabelModel.from_config_dict(cfg.preprocessor)
         self.encoder = EncDecSpeakerLabelModel.from_config_dict(cfg.encoder)
         self.decoder = EncDecSpeakerLabelModel.from_config_dict(cfg.decoder)
@@ -103,6 +113,28 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel):
             self.loss = CELoss()
         self.task = None
         self._accuracy = TopKClassificationAccuracy(top_k=[1])
+        self.labels = None
+
+    @staticmethod
+    def extract_labels(data_layer_config):
+        labels = set()
+        manifest_filepath = data_layer_config.get('manifest_filepath', None)
+        if manifest_filepath is None:
+            logging.warning("No manifest_filepath was provided, no labels got extracted!")
+            return None
+        manifest_filepaths = convert_to_config_list(data_layer_config['manifest_filepath'])
+
+        for manifest_filepath in itertools.chain.from_iterable(manifest_filepaths):
+            collection = ASRSpeechLabel(
+                manifests_files=manifest_filepath,
+                min_duration=data_layer_config.get("min_duration", None),
+                max_duration=data_layer_config.get("max_duration", None),
+                index_by_file_id=True,  # Must set this so the manifest lines can be indexed by file ID
+            )
+            labels.update(collection.uniq_labels)
+        labels = list(labels)
+        logging.warning(f"Total number of {len(labels)} found in all the manifest files.")
+        return labels
 
     def __setup_dataloader_from_config(self, config: Optional[Dict]):
         if 'augmentor' in config:
@@ -113,32 +145,63 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel):
         featurizer = WaveformFeaturizer(
             sample_rate=config['sample_rate'], int_values=config.get('int_values', False), augmentor=augmentor
         )
-        self.dataset = AudioToSpeechLabelDataset(
-            manifest_filepath=config['manifest_filepath'],
-            labels=config['labels'],
-            featurizer=featurizer,
-            max_duration=config.get('max_duration', None),
-            min_duration=config.get('min_duration', None),
-            trim=False,
-            time_length=config.get('time_length', 8),
-            shift_length=config.get('shift_length', 0.75),
-        )
+        shuffle = config.get('shuffle', False)
+        if config.get('is_tarred', False):
+            if ('tarred_audio_filepaths' in config and config['tarred_audio_filepaths'] is None) or (
+                'manifest_filepath' in config and config['manifest_filepath'] is None
+            ):
+                logging.warning(
+                    "Could not load dataset as `manifest_filepath` was None or "
+                    f"`tarred_audio_filepaths` is None. Provided config : {config}"
+                )
+                return None
+
+            shuffle_n = config.get('shuffle_n', 4 * config['batch_size']) if shuffle else 0
+            dataset = get_tarred_speech_label_dataset(
+                featurizer=featurizer,
+                config=config,
+                shuffle_n=shuffle_n,
+                global_rank=self.global_rank,
+                world_size=self.world_size,
+            )
+            shuffle = False
+        else:
+            if 'manifest_filepath' in config and config['manifest_filepath'] is None:
+                logging.warning(f"Could not load dataset as `manifest_filepath` was None. Provided config : {config}")
+                return None
+
+            dataset = AudioToSpeechLabelDataset(
+                manifest_filepath=config['manifest_filepath'],
+                labels=config['labels'],
+                featurizer=featurizer,
+                max_duration=config.get('max_duration', None),
+                min_duration=config.get('min_duration', None),
+                trim=config.get('trim_silence', False),
+                time_length=config.get('time_length', 8),
+                shift_length=config.get('shift_length', 0.75),
+                normalize_audio=config.get('normalize_audio', False),
+            )
+
+        if type(dataset) is ChainDataset:
+            collate_ds = dataset.datasets[0]
+        else:
+            collate_ds = dataset
+
+        # self.labels = collate_ds.labels
 
         if self.task == 'diarization':
             logging.info("Setting up diarization parameters")
-            _collate_func = self.dataset.sliced_seq_collate_fn
-            batch_size = config['batch_size']
+            collate_fn = collate_ds.sliced_seq_collate_fn
             shuffle = False
         else:
             logging.info("Setting up identification parameters")
-            _collate_func = self.dataset.fixed_seq_collate_fn
-            batch_size = config['batch_size']
-            shuffle = config.get('shuffle', False)
+            collate_fn = collate_ds.fixed_seq_collate_fn
 
+        batch_size = config['batch_size']
         return torch.utils.data.DataLoader(
-            dataset=self.dataset,
+            dataset=dataset,
             batch_size=batch_size,
-            collate_fn=_collate_func,
+            collate_fn=collate_fn,
             drop_last=config.get('drop_last', False),
             shuffle=shuffle,
             num_workers=config.get('num_workers', 0),
@@ -146,19 +209,21 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel):
         )
 
     def setup_training_data(self, train_data_layer_config: Optional[Union[DictConfig, Dict]]):
+        self.labels = self.extract_labels(train_data_layer_config)
+        train_data_layer_config['labels'] = self.labels
         if 'shuffle' not in train_data_layer_config:
             train_data_layer_config['shuffle'] = True
         self.task = 'identification'
         self._train_dl = self.__setup_dataloader_from_config(config=train_data_layer_config)
 
     def setup_validation_data(self, val_data_layer_config: Optional[Union[DictConfig, Dict]]):
-        val_data_layer_config['labels'] = self.dataset.labels
+        val_data_layer_config['labels'] = self.labels
         self.task = 'identification'
         self._validation_dl = self.__setup_dataloader_from_config(config=val_data_layer_config)
 
     def setup_test_data(self, test_data_layer_params: Optional[Union[DictConfig, Dict]]):
         if hasattr(self, 'dataset'):
-            test_data_layer_params['labels'] = self.dataset.labels
+            test_data_layer_params['labels'] = self.labels
 
         if 'task' in test_data_layer_params and test_data_layer_params['task']:
             self.task = test_data_layer_params['task'].lower()
@@ -299,11 +364,6 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel):
         make sure you set num_classes correctly for finetune data
         Returns: None
         """
-        if hasattr(self, 'dataset'):
-            scratch_labels = self.dataset.labels
-        else:
-            scratch_labels = None
-
         logging.info("Setting up data loaders with manifests provided from model_config")
 
         if 'train_ds' in model_config and model_config.train_ds is not None:
@@ -311,8 +371,8 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel):
         else:
             raise KeyError("train_ds is not found in model_config but you need it for fine tuning")
 
-        if self.dataset.labels is None or len(self.dataset.labels) == 0:
-            raise ValueError(f'New labels must be non-empty list of labels. But I got: {self.dataset.labels}')
+        if self.labels is None or len(self.labels) == 0:
+            raise ValueError(f'New labels must be non-empty list of labels. But I got: {self.labels}')
 
         if 'validation_ds' in model_config and model_config.validation_ds is not None:
             self.setup_multiple_validation_data(model_config.validation_ds)
@@ -320,21 +380,21 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel):
         if 'test_ds' in model_config and model_config.test_ds is not None:
             self.setup_multiple_test_data(model_config.test_ds)
 
-        if scratch_labels == self.dataset.labels:  # checking for new finetune dataset labels
+        if self.labels is not None:  # checking for new finetune dataset labels
             logging.warning(
                 "Trained dataset labels are same as finetune dataset labels -- continuing change of decoder parameters"
             )
-        elif scratch_labels is None:
+        else:
             logging.warning(
                 "Either you provided a dummy manifest file during training from scratch or you restored from a pretrained nemo file"
             )
 
         decoder_config = model_config.decoder
         new_decoder_config = copy.deepcopy(decoder_config)
-        if new_decoder_config['num_classes'] != len(self.dataset.labels):
+        if new_decoder_config['num_classes'] != len(self.labels):
             raise ValueError(
                 "number of classes provided {} is not same as number of different labels in finetuning data: {}".format(
-                    new_decoder_config['num_classes'], len(self.dataset.labels)
+                    new_decoder_config['num_classes'], len(self.labels)
                 )
             )
 

--- a/nemo/collections/asr/models/rnnt_bpe_models.py
+++ b/nemo/collections/asr/models/rnnt_bpe_models.py
@@ -114,6 +114,13 @@ class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):
         )
         results.append(model)
 
+        model = PretrainedModelInfo(
+            pretrained_model_name="stt_de_contextnet_1024",
+            description="For details about this model, please visit https://ngc.nvidia.com/catalog/models/nvidia:nemo:stt_de_contextnet_1024",
+            location="https://api.ngc.nvidia.com/v2/models/nvidia/nemo/stt_de_contextnet_1024/versions/1.4.0/files/stt_de_contextnet_1024.nemo",
+        )
+        results.append(model)
+
         return results
 
     def __init__(self, cfg: DictConfig, trainer: Trainer = None):

--- a/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
@@ -784,7 +784,7 @@ class BeamRNNTInfer(Typing):
 
             for bid, hyp in enumerate(B):
                 u = len(hyp.y_sequence) - 1
-                t = i - u + 1
+                t = i - u
 
                 if t > (h_length - 1):
                     batch_removal_ids.append(bid)

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -262,7 +262,7 @@ class MegatronGPTModel(NLPModel):
 
     def setup_training_data(self, cfg):
         if hasattr(self, '_train_ds'):
-            resume_checkpoint_path = self.trainer.checkpoint_connector.resume_checkpoint_path
+            resume_checkpoint_path = self.trainer.checkpoint_connector.resume_from_checkpoint_fit_path
             if resume_checkpoint_path:
                 consumed_samples = int(
                     float(re.findall(r"consumed_samples\=([0-9]+.[0-9]+)", resume_checkpoint_path)[0])

--- a/nemo/collections/nlp/models/text2sparql/text2sparql_model.py
+++ b/nemo/collections/nlp/models/text2sparql/text2sparql_model.py
@@ -177,6 +177,7 @@ class Text2SparqlModel(ModelPT):
         perplexity = self.validation_perplexity.compute()
         tensorboard_logs = {"val_loss": avg_loss, "perplexity": perplexity}
         logging.info(f"evaluation perplexity {perplexity.item()}")
+        self.log("val_loss", avg_loss)
         return {"val_loss": avg_loss, "log": tensorboard_logs}
 
     @typecheck.disable_checks()
@@ -190,6 +191,7 @@ class Text2SparqlModel(ModelPT):
     def test_epoch_end(self, outputs: List[torch.Tensor]) -> Dict[str, List[str]]:
         """Called at the end of test to aggregate outputs and decode them."""
         texts = [self.encoder_tokenizer.ids_to_text(seq) for batch in outputs for seq in batch]
+        self.test_output = [{"texts": texts}]
         return {"texts": texts}
 
     def setup_tokenizer(self, cfg: DictConfig):

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -38,16 +38,6 @@ except (ImportError, ModuleNotFoundError):
 
     HAVE_APEX = False
 
-try:
-    from apex.transformer import parallel_state
-    from nemo.collections.nlp.modules.common.megatron.clip_grads import clip_grad_norm_fp32
-
-    HAVE_APEX = True
-
-except (ImportError, ModuleNotFoundError):
-
-    HAVE_APEX = False
-
 
 class NLPDDPPlugin(DDPPlugin):
     """ DDP plugin for Pytorch Lightning. Needed to customize DDP for model parallel models.

--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -194,7 +194,7 @@ def exp_manager(trainer: 'pytorch_lightning.Trainer', cfg: Optional[Union[DictCo
                 lightning's TensorboardLogger system of using version_{int}.
             - use_datetime_version (bool): Whether to use a datetime string for version. Defaults to True.
             - resume_if_exists (bool): Whether this experiment is resuming from a previous run. If True, it sets
-                trainer.checkpoint_connector.resume_checkpoint_path so that the trainer should auto-resume. exp_manager will move files
+                trainer.checkpoint_connector.resume_from_checkpoint_fit_path so that the trainer should auto-resume. exp_manager will move files
                 under log_dir to log_dir/run_{int}. Defaults to False. From v1.0.0, when resume_if_exists is True,
                 we would not create version folders to make it easier to find the log folder for next runs.
             - resume_past_end (bool): exp_manager errors out if resume_if_exists is True and a checkpoint matching
@@ -385,7 +385,7 @@ def check_resume(
     resume_ignore_no_checkpoint: bool = False,
 ):
     """Checks that resume=True was used correctly with the arguments pass to exp_manager. Sets
-    trainer.checkpoint_connector.resume_checkpoint_path as necessary.
+    trainer.checkpoint_connector.resume_from_checkpoint_fit_path as necessary.
 
     Returns:
         log_dir (Path): the log_dir
@@ -441,7 +441,7 @@ def check_resume(
         logging.info(f"Resuming from {last_checkpoints[0]}")
         checkpoint = last_checkpoints[0]
 
-    trainer.checkpoint_connector.resume_checkpoint_path = str(checkpoint)
+    trainer.checkpoint_connector.resume_from_checkpoint_fit_path = str(checkpoint)
 
     if is_global_rank_zero():
         # Check to see if any files exist that need to be moved
@@ -883,7 +883,7 @@ def configure_checkpointing(
             )
 
     checkpoint_callback = NeMoModelCheckpoint(n_resume=resume, **params)
-    checkpoint_callback.last_model_path = trainer.checkpoint_connector.resume_checkpoint_path or ""
+    checkpoint_callback.last_model_path = trainer.checkpoint_connector.resume_from_checkpoint_fit_path or ""
     if params.model_parallel_size is not None and params.model_parallel_size > 1:
         checkpoint_callback.last_model_path = NeMoModelCheckpoint._uninject_mp_rank(
             checkpoint_callback.last_model_path

--- a/requirements/requirements_nlp.txt
+++ b/requirements/requirements_nlp.txt
@@ -9,7 +9,7 @@ gdown
 inflect
 sacrebleu[ja]
 sacremoses>=0.0.43
-nltk>=3.6.4
+nltk>=3.6.5
 wordninja==2.0.0
 fasttext
 opencc

--- a/tutorials/nlp/Entity_Linking_Medical.ipynb
+++ b/tutorials/nlp/Entity_Linking_Medical.ipynb
@@ -38,6 +38,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "## Install dependencies\n",
+    "!pip install wget\n",
+    "!pip install faiss-gpu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import faiss\n",
     "import torch\n",
     "import wget\n",

--- a/tutorials/text_processing/WFST_Tutorial.ipynb
+++ b/tutorials/text_processing/WFST_Tutorial.ipynb
@@ -14,7 +14,7 @@
    "source": [
     "### WARNING: This notebook will not work in a Colab environment. \n",
     "\n",
-    "BRANCH= \"r1.5.0\"\n",
+    "BRANCH= \"main\"\n",
     "\n",
     "!git clone -b $BRANCH https://github.com/NVIDIA/NeMo\n",
     "%cd NeMo\n",


### PR DESCRIPTION
* update branch

Signed-off-by: ericharper <complex451@gmail.com>

* Always save last checkpoint on train end even if folder does not exist (#2976)

* add fix for no checkpoint folder when training ends

Signed-off-by: Jason <jasoli@nvidia.com>

* update

Signed-off-by: Jason <jasoli@nvidia.com>

* fix test

Signed-off-by: Jason <jasoli@nvidia.com>

* fixes

Signed-off-by: Jason <jasoli@nvidia.com>

* typo

Signed-off-by: Jason <jasoli@nvidia.com>

* change check

Signed-off-by: Jason <jasoli@nvidia.com>

* Update reinstall and cherry-pick bignlp commits (#3065)

* add ptl install to reinstall and update jenkins install

Signed-off-by: ericharper <complex451@gmail.com>

* Add a stateless timer to specify max_time per run instead of global m… (#3056)

* Add a stateless timer to specify max_time per run instead of global max_time across runs

Signed-off-by: MaximumEntropy <sandeep.subramanian.1@umontreal.ca>

* Style fixes

Signed-off-by: MaximumEntropy <sandeep.subramanian.1@umontreal.ca>

* (1) reduce the validation loss within a epoch, (2) convert global-batch-based iteartion counts to micro-batch-based (#3055)

Co-authored-by: Oleksii Kuchaiev <okuchaiev@users.noreply.github.com>

* Timer class monitors total time (train + validation + testing) to monitor when to end training (#3061)

* Check total time in train/validation to exit

Signed-off-by: MaximumEntropy <sandeep.subramanian.1@umontreal.ca>

* Style fixes

Signed-off-by: MaximumEntropy <sandeep.subramanian.1@umontreal.ca>

Co-authored-by: Oleksii Kuchaiev <okuchaiev@users.noreply.github.com>

* Add PUBLICATIONS.md (#3051)

* Add PUBLICATIONS.md

Signed-off-by: smajumdar <titu1994@gmail.com>

* Add NLP

Signed-off-by: smajumdar <titu1994@gmail.com>

* Update PUBLICATIONS.md

* Update PUBLICATIONS.md

* Fix links

Signed-off-by: smajumdar <titu1994@gmail.com>

Co-authored-by: Eric Harper <complex451@gmail.com>

* fix uninstall

Signed-off-by: ericharper <complex451@gmail.com>

Co-authored-by: Sandeep Subramanian <sandeep.subramanian.1@umontreal.ca>
Co-authored-by: Sangkug Lym <slym@nvidia.com>
Co-authored-by: Oleksii Kuchaiev <okuchaiev@users.noreply.github.com>
Co-authored-by: Somshubra Majumdar <titu1994@gmail.com>

* Exp manager small refactor (#3067)

* Exp manager small refactor

Signed-off-by: MaximumEntropy <sandeep.subramanian.1@umontreal.ca>

* move super() call earlier in the function

Signed-off-by: MaximumEntropy <sandeep.subramanian.1@umontreal.ca>

Co-authored-by: Somshubra Majumdar <titu1994@gmail.com>

* Fix save top k (#3075)

* inject mp_rank for checkpoint paths in NLPDDPPlugin

Signed-off-by: ericharper <complex451@gmail.com>

* == instead of i

Signed-off-by: ericharper <complex451@gmail.com>

* when checking previous run account for mp

Signed-off-by: ericharper <complex451@gmail.com>

* uninject mp ranks when needed

Signed-off-by: ericharper <complex451@gmail.com>

* style

Signed-off-by: ericharper <complex451@gmail.com>

* Upgrade to PTL 1.5.0 (#3127)

* update for ptl 1.5.0

Signed-off-by: ericharper <complex451@gmail.com>

* update trainer config

Signed-off-by: ericharper <complex451@gmail.com>

* limit cuda visible devices to the first two gpus on check for ranks CI test

Signed-off-by: ericharper <complex451@gmail.com>

* remove comments

Signed-off-by: ericharper <complex451@gmail.com>

* make datasets larger for test

Signed-off-by: ericharper <complex451@gmail.com>

* make datasets larger for test

Signed-off-by: ericharper <complex451@gmail.com>

* update compute_max_steps

Signed-off-by: ericharper <complex451@gmail.com>

* update compute_max_steps

Signed-off-by: ericharper <complex451@gmail.com>

* added to avail models (#3044)

Signed-off-by: Yang Zhang <yangzhang@nvidia.com>

* config link fixes (#3148)

Signed-off-by: nithinraok <nithinrao.koluguri@gmail.com>

* fix nemo checkpoint converter (#3149)

Signed-off-by: Yu Yao <yuya@nvidia.com>

Co-authored-by: Yu Yao <yuya@nvidia.com>
Co-authored-by: Eric Harper <complex451@gmail.com>

* [BigNLP] Add CI Tests for Megatron GPT (#3124)

* add pretrain CI test

Signed-off-by: ericharper <complex451@gmail.com>

* update test

Signed-off-by: ericharper <complex451@gmail.com>

* update test

Signed-off-by: ericharper <complex451@gmail.com>

* update test

Signed-off-by: ericharper <complex451@gmail.com>

* add .cpp and Makefile to python package_data

Signed-off-by: ericharper <complex451@gmail.com>

* check for local_rank and barrier when compiling helper

Signed-off-by: ericharper <complex451@gmail.com>

* check for local_rank and barrier when compiling helper

Signed-off-by: ericharper <complex451@gmail.com>

* remove comment

Signed-off-by: ericharper <complex451@gmail.com>

* remove comment

Signed-off-by: ericharper <complex451@gmail.com>

* add device, have jenkins test use fp16

Signed-off-by: ericharper <complex451@gmail.com>

* add device, have jenkins test use fp16

Signed-off-by: ericharper <complex451@gmail.com>

* update app_state.local_rank

Signed-off-by: ericharper <complex451@gmail.com>

* update config

Signed-off-by: ericharper <complex451@gmail.com>

* add configure gradient clipping hook

Signed-off-by: ericharper <complex451@gmail.com>

* style

Signed-off-by: ericharper <complex451@gmail.com>

* add configure gradient clipping hook

Signed-off-by: ericharper <complex451@gmail.com>

* add resume test

Signed-off-by: ericharper <complex451@gmail.com>

* add eval

Signed-off-by: ericharper <complex451@gmail.com>

* add eval

Signed-off-by: ericharper <complex451@gmail.com>

* (1) update auto-casting api, (2) simplifiy precision arguments and remove redundancy (#3142)

Signed-off-by: Sangkug Lym <slym@nvidia.com>

* only set jit fusion options if we are in 21.10 container

Signed-off-by: ericharper <complex451@gmail.com>

* update arg

Signed-off-by: ericharper <complex451@gmail.com>

* update nemo file for eval test

Signed-off-by: ericharper <complex451@gmail.com>

* remove unused import

Signed-off-by: ericharper <complex451@gmail.com>

* remove unused import

Signed-off-by: ericharper <complex451@gmail.com>

* move tests down in the jenkinsfile

Signed-off-by: ericharper <complex451@gmail.com>

* style

Signed-off-by: ericharper <complex451@gmail.com>

* removed fused arg

Signed-off-by: ericharper <complex451@gmail.com>

* interpolate precision and sequence length in config

Signed-off-by: ericharper <complex451@gmail.com>

* remove trainer.precision interpolation

Signed-off-by: ericharper <complex451@gmail.com>

* remove nemo_experiments after prallel stage

Signed-off-by: ericharper <complex451@gmail.com>

* remove rm call

Signed-off-by: ericharper <complex451@gmail.com>

Co-authored-by: Sangkug Lym <slym@nvidia.com>

* Notebook bugfixes (#3165)

* zero shot intent slot notebook bug fix

Signed-off-by: Virginia Adams <vadams@nvidia.com>

* Added megatronBERT not support in this release message to notebook

Signed-off-by: Virginia Adams <vadams@nvidia.com>

* added apex backend to config

Signed-off-by: Virginia Adams <vadams@nvidia.com>

* Removed apex from entity linking and added 1.4.0 nemo info to warning

Co-authored-by: Eric Harper <complex451@gmail.com>

* remove cfg in _load_model_state in nlp_models (#3172)

* remove cfg in _load_model_state in nlp_models

Signed-off-by: fayejf <fayejf07@gmail.com>

* style fix

Signed-off-by: fayejf <fayejf07@gmail.com>

* Change cfg.cuda type to optional int in schema (#3126)

* Change cfg.cuda type to optional int in schema

Signed-off-by: Elena Rastorgueva <erastorgueva@nvidia.com>

* Update device-setting logic

Signed-off-by: Elena Rastorgueva <erastorgueva@nvidia.com>

* Allow any negative cfg.cuda to mean run on cpu

Signed-off-by: Elena Rastorgueva <erastorgueva@nvidia.com>

* Fix typo and pass correct num of GPUs to pl Trainer

Signed-off-by: Elena Rastorgueva <erastorgueva@nvidia.com>

* Style fixes

Signed-off-by: Elena Rastorgueva <erastorgueva@nvidia.com>

* Fix bugs in deciding which GPU to use

Signed-off-by: Elena Rastorgueva <erastorgueva@nvidia.com>

* Rename  variable to

Signed-off-by: Elena Rastorgueva <erastorgueva@nvidia.com>

* Update transcribe_speech test in Jenkinsfile

Signed-off-by: Elena Rastorgueva <erastorgueva@nvidia.com>

* Revert name cuda_device to cuda

Signed-off-by: Elena Rastorgueva <erastorgueva@nvidia.com>

* Fix the tarred and bucketing support for speech label model (#3046)

* fix gpt ckpt resume path (#3178)

Signed-off-by: ericharper <complex451@gmail.com>

* Update branch name for torchtext in Dockerfile (#3190)

Signed-off-by: Elena Rastorgueva <erastorgueva@nvidia.com>

* convert str to list if needed. (#3193)

Signed-off-by: Vahid <vnoroozi@nvidia.com>

* quickfix for restore (#3201)

Signed-off-by: Jason <jasoli@nvidia.com>

* Fix RNNT ALSD Decoding Indexing bug (#3202)

Signed-off-by: smajumdar <titu1994@gmail.com>

* NLTK version fix (#3204)

Signed-off-by: Oleksii Kuchaiev <okuchaiev@nvidia.com>

* edit README

Signed-off-by: Oleksii Kuchaiev <okuchaiev@nvidia.com>

* text2sparql val loss logging fix (#3213)

* text2sparql val loss logging fix

Signed-off-by: Oleksii Kuchaiev <okuchaiev@nvidia.com>

* store test output

Signed-off-by: ericharper <complex451@gmail.com>

Co-authored-by: ericharper <complex451@gmail.com>

* update package info and resume_from in gpt example

Signed-off-by: ericharper <complex451@gmail.com>

* update README

Signed-off-by: ericharper <complex451@gmail.com>

* update branch to main

Signed-off-by: ericharper <complex451@gmail.com>

* rebase

Signed-off-by: ericharper <complex451@gmail.com>

Co-authored-by: Jason <jasoli@nvidia.com>
Co-authored-by: Sandeep Subramanian <sandeep.subramanian.1@umontreal.ca>
Co-authored-by: Sangkug Lym <slym@nvidia.com>
Co-authored-by: Oleksii Kuchaiev <okuchaiev@users.noreply.github.com>
Co-authored-by: Somshubra Majumdar <titu1994@gmail.com>
Co-authored-by: Yang Zhang <yzhang123@users.noreply.github.com>
Co-authored-by: Nithin Rao <nithinrao.koluguri@gmail.com>
Co-authored-by: yaoyu-33 <54727607+yaoyu-33@users.noreply.github.com>
Co-authored-by: Yu Yao <yuya@nvidia.com>
Co-authored-by: vadam5 <78445382+vadam5@users.noreply.github.com>
Co-authored-by: fayejf <36722593+fayejf@users.noreply.github.com>
Co-authored-by: Elena Rastorgueva <80532067+erastorgueva-nv@users.noreply.github.com>
Co-authored-by: Vahid Noroozi <VahidooX@users.noreply.github.com>
Co-authored-by: Oleksii Kuchaiev <okuchaiev@nvidia.com>